### PR TITLE
v1.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,6 @@
 {% set name = "portpicker" %}
-{% set version = "1.3.1" %}
+{% set version = "1.5.2" %}
 {% set file_ext = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash_value = "d2cdc776873635ed421315c4d22e63280042456bbfa07397817e687b142b9667" %}
 
 package:
   name: {{ name|lower }}
@@ -11,29 +9,34 @@ package:
 source:
   fn: {{ name }}-{{ version }}.{{ file_ext }}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
-  {{ hash_type }}: {{ hash_value }}
+  sha256: "c55683ad725f5c00a41bc7db0225223e8be024b1fa564d039ed3390e4fd48fb3"
 
 build:
   number: 0
-  script: python setup.py install
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
+  skip: true  # [py<37]
 
 requirements:
   host:
     - python
     - setuptools
+    - pip
+    - wheel
 
   run:
     - python
+    - psutil
 
 test:
   requires:
-    - mock  [py27]
+    - pip
   imports:
     - portpicker
   source_files:
     - src/tests
   commands:
     - python src/tests/portpicker_test.py
+    - pip check
 
 about:
   home: https://pypi.python.org/pypi/portpicker

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,8 @@ test:
     - pip check
 
 about:
-  home: https://pypi.python.org/pypi/portpicker
-  license: Apache License 2.0
+  home: https://pypi.org/project/portpicker/
+  license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   summary: A library to choose unique available network ports.
@@ -50,6 +50,7 @@ about:
     for use from unittests or for test harnesses that launch
     local servers.
   dev_url: https://github.com/google/python_portpicker
+  doc_url: https://github.com/google/python_portpicker
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
upstream: https://github.com/google/python_portpicker/tree/v1.5.2
jira: https://anaconda.atlassian.net/browse/PKG-1398
`setup.cfg`: https://github.com/google/python_portpicker/blob/v1.5.2/setup.cfg#L36

## Changes
- Remove jinja variables only used once
- Use pip install
- Update about section